### PR TITLE
Binary Cache Support

### DIFF
--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -275,11 +275,23 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 
 	// Host Actions
 	case UpdatePendingSystemNetwork:
+		t.enqueue(j)
+
 	case EnableSSH:
+		t.enqueue(j)
+
 	case DisableSSH:
+		t.enqueue(j)
+
 	case AddSSHKey:
+		t.enqueue(j)
+
 	case RemoveSSHKey:
+		t.enqueue(j)
+
 	case AddBinaryCache:
+		t.enqueue(j)
+
 	case RemoveBinaryCache:
 		t.enqueue(j)
 

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -275,18 +275,12 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 
 	// Host Actions
 	case UpdatePendingSystemNetwork:
-		t.enqueue(j)
-
 	case EnableSSH:
-		t.enqueue(j)
-
 	case DisableSSH:
-		t.enqueue(j)
-
 	case AddSSHKey:
-		t.enqueue(j)
-
 	case RemoveSSHKey:
+	case AddBinaryCache:
+	case RemoveBinaryCache:
 		t.enqueue(j)
 
 	// Pup router actions

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -129,6 +129,15 @@ type RemoveSSHKey struct {
 // Import blockchain data to the system (not tied to a specific pup)
 type ImportBlockchainData struct{}
 
+type AddBinaryCache struct {
+	Host string
+	Key  string
+}
+
+type RemoveBinaryCache struct {
+	ID string
+}
+
 /* Updates are responses to Actions or simply
 * internal state changes that the frontend needs,
 * these are wrapped in a 'change' and sent via

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -19,6 +19,7 @@ type SystemUpdater interface {
 	AddSSHKey(key string, l SubLogger) error
 	EnableSSH(l SubLogger) error
 	ListSSHKeys() ([]DogeboxStateSSHKey, error)
+	AddBinaryCache(j AddBinaryCache, l SubLogger) error
 }
 
 // monitors systemd services and returns stats

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -71,6 +71,7 @@ type DogeboxStateSSHConfig struct {
 }
 
 type DogeboxStateBinaryCache struct {
+	ID   string `json:"id"`
 	Host string `json:"host"`
 	Key  string `json:"key"`
 }

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -70,6 +70,11 @@ type DogeboxStateSSHConfig struct {
 	Keys    []DogeboxStateSSHKey `json:"keys"`
 }
 
+type DogeboxStateBinaryCache struct {
+	Host string `json:"host"`
+	Key  string `json:"key"`
+}
+
 type DogeboxState struct {
 	InitialState  DogeboxStateInitialSetup
 	Hostname      string
@@ -77,6 +82,7 @@ type DogeboxState struct {
 	SSH           DogeboxStateSSHConfig
 	StorageDevice string
 	Flags         DogeboxFlags
+	BinaryCaches  []DogeboxStateBinaryCache
 }
 
 type NetworkState struct {
@@ -294,10 +300,12 @@ type NixFirewallTemplateValues struct {
 }
 
 type NixSystemTemplateValues struct {
-	SYSTEM_HOSTNAME string
-	KEYMAP          string
-	SSH_ENABLED     bool
-	SSH_KEYS        []DogeboxStateSSHKey
+	SYSTEM_HOSTNAME   string
+	KEYMAP            string
+	SSH_ENABLED       bool
+	SSH_KEYS          []DogeboxStateSSHKey
+	BINARY_CACHE_SUBS []string
+	BINARY_CACHE_KEYS []string
 }
 
 type NixIncludesFileTemplateValues struct {

--- a/pkg/system/nix/templates/system.nix
+++ b/pkg/system/nix/templates/system.nix
@@ -38,11 +38,11 @@
 
   {{ range .BINARY_CACHE_SUBS }}
   nix.settings.substituters = [
-    {{.}}
+    "{{.}}"
   ];{{ end }}
 
   {{ range .BINARY_CACHE_KEYS }}
   nix.settings.trusted-public-keys = [
-    {{.}}
+    "{{.}}"
   ];{{ end }}
 }

--- a/pkg/system/nix/templates/system.nix
+++ b/pkg/system/nix/templates/system.nix
@@ -35,4 +35,14 @@
       };
     };
   };
+
+  {{ range .BINARY_CACHE_SUBS }}
+  nix.settings.substituters = [
+    {{.}}
+  ];{{ end }}
+
+  {{ range .BINARY_CACHE_KEYS }}
+  nix.settings.trusted-public-keys = [
+    {{.}}
+  ];{{ end }}
 }

--- a/pkg/system/ssh.go
+++ b/pkg/system/ssh.go
@@ -7,27 +7,15 @@ import (
 	"time"
 
 	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+	"github.com/dogeorg/dogeboxd/pkg/utils"
 )
 
 func (t SystemUpdater) sshUpdate(dbxState dogeboxd.DogeboxState, log dogeboxd.SubLogger) error {
 	patch := t.nix.NewPatch(log)
 	t.nix.UpdateFirewallRules(patch, dbxState)
 
-	binaryCacheSubs := []string{}
-	binaryCacheKeys := []string{}
-	for _, cache := range dbxState.BinaryCaches {
-		binaryCacheSubs = append(binaryCacheSubs, cache.Host)
-		binaryCacheKeys = append(binaryCacheKeys, cache.Key)
-	}
-
-	t.nix.UpdateSystem(patch, dogeboxd.NixSystemTemplateValues{
-		SYSTEM_HOSTNAME:   dbxState.Hostname,
-		SSH_ENABLED:       dbxState.SSH.Enabled,
-		SSH_KEYS:          dbxState.SSH.Keys,
-		KEYMAP:            dbxState.KeyMap,
-		BINARY_CACHE_SUBS: binaryCacheSubs,
-		BINARY_CACHE_KEYS: binaryCacheKeys,
-	})
+	values := utils.GetNixSystemTemplateValues(dbxState)
+	t.nix.UpdateSystem(patch, values)
 
 	if err := patch.Apply(); err != nil {
 		log.Errf("Failed to enable SSH: %v", err)

--- a/pkg/system/ssh.go
+++ b/pkg/system/ssh.go
@@ -12,11 +12,21 @@ import (
 func (t SystemUpdater) sshUpdate(dbxState dogeboxd.DogeboxState, log dogeboxd.SubLogger) error {
 	patch := t.nix.NewPatch(log)
 	t.nix.UpdateFirewallRules(patch, dbxState)
+
+	binaryCacheSubs := []string{}
+	binaryCacheKeys := []string{}
+	for _, cache := range dbxState.BinaryCaches {
+		binaryCacheSubs = append(binaryCacheSubs, cache.Host)
+		binaryCacheKeys = append(binaryCacheKeys, cache.Key)
+	}
+
 	t.nix.UpdateSystem(patch, dogeboxd.NixSystemTemplateValues{
-		SYSTEM_HOSTNAME: dbxState.Hostname,
-		SSH_ENABLED:     dbxState.SSH.Enabled,
-		SSH_KEYS:        dbxState.SSH.Keys,
-		KEYMAP:          dbxState.KeyMap,
+		SYSTEM_HOSTNAME:   dbxState.Hostname,
+		SSH_ENABLED:       dbxState.SSH.Enabled,
+		SSH_KEYS:          dbxState.SSH.Keys,
+		KEYMAP:            dbxState.KeyMap,
+		BINARY_CACHE_SUBS: binaryCacheSubs,
+		BINARY_CACHE_KEYS: binaryCacheKeys,
 	})
 
 	if err := patch.Apply(); err != nil {

--- a/pkg/system/updater.go
+++ b/pkg/system/updater.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	_ "embed"
 	"fmt"
@@ -128,6 +129,20 @@ func (t SystemUpdater) Run(started, stopped chan bool, stop chan context.Context
 						err := t.RemoveSSHKey(a.ID, j.Logger.Step("remove SSH key"))
 						if err != nil {
 							j.Err = "Failed to remove SSH key"
+						}
+						t.done <- j
+
+					case dogeboxd.AddBinaryCache:
+						err := t.addBinaryCache(a)
+						if err != nil {
+							j.Err = "Failed to add binary cache"
+						}
+						t.done <- j
+
+					case dogeboxd.RemoveBinaryCache:
+						err := t.removeBinaryCache(a)
+						if err != nil {
+							j.Err = "Failed to remove binary cache"
 						}
 						t.done <- j
 
@@ -477,4 +492,39 @@ func (t SystemUpdater) importBlockchainData(j dogeboxd.Job) error {
 
 	log.Log("Blockchain data import completed successfully")
 	return nil
+}
+
+func (t SystemUpdater) addBinaryCache(j dogeboxd.AddBinaryCache) error {
+	dbxState := t.sm.Get().Dogebox
+
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		return fmt.Errorf("failed to generate random ID for binary cache: %v", err)
+	}
+
+	dbxState.BinaryCaches = append(dbxState.BinaryCaches, dogeboxd.DogeboxStateBinaryCache{
+		ID:   string(id),
+		Host: j.Host,
+		Key:  j.Key,
+	})
+
+	return t.sm.SetDogebox(dbxState)
+}
+
+func (t SystemUpdater) removeBinaryCache(j dogeboxd.RemoveBinaryCache) error {
+	dbxState := t.sm.Get().Dogebox
+
+	keyFound := false
+	for i, cache := range dbxState.BinaryCaches {
+		if cache.ID == j.ID {
+			dbxState.BinaryCaches = append(dbxState.BinaryCaches[:i], dbxState.BinaryCaches[i+1:]...)
+			keyFound = true
+		}
+	}
+
+	if !keyFound {
+		return fmt.Errorf("binary cache with ID %s not found", j.ID)
+	}
+
+	return t.sm.SetDogebox(dbxState)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -137,3 +137,21 @@ func GetPupNixDevelopmentModeServices(config dogeboxd.ServerConfig, diskSourcePa
 
 	return devServices, nil
 }
+
+func GetNixSystemTemplateValues(dbxState dogeboxd.DogeboxState) dogeboxd.NixSystemTemplateValues {
+	binaryCacheSubs := []string{}
+	binaryCacheKeys := []string{}
+	for _, cache := range dbxState.BinaryCaches {
+		binaryCacheSubs = append(binaryCacheSubs, cache.Host)
+		binaryCacheKeys = append(binaryCacheKeys, cache.Key)
+	}
+
+	return dogeboxd.NixSystemTemplateValues{
+		SYSTEM_HOSTNAME:   dbxState.Hostname,
+		SSH_ENABLED:       dbxState.SSH.Enabled,
+		SSH_KEYS:          dbxState.SSH.Keys,
+		KEYMAP:            dbxState.KeyMap,
+		BINARY_CACHE_SUBS: binaryCacheSubs,
+		BINARY_CACHE_KEYS: binaryCacheKeys,
+	}
+}

--- a/pkg/web/binary_caches.go
+++ b/pkg/web/binary_caches.go
@@ -1,0 +1,75 @@
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+)
+
+type AddBinaryCacheRequest struct {
+	Host string `json:"host"`
+	Key  string `json:"key"`
+}
+
+func (a api) getBinaryCaches(w http.ResponseWriter, r *http.Request) {
+	dbxState := a.sm.Get().Dogebox
+	sendResponse(w, dbxState.BinaryCaches)
+}
+
+func (a api) addBinaryCache(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error reading request body")
+		return
+	}
+
+	var req AddBinaryCacheRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error unmarshalling JSON")
+		return
+	}
+
+	dbxState := a.sm.Get().Dogebox
+
+	for _, existingCache := range dbxState.BinaryCaches {
+		if existingCache.Host == req.Host {
+			sendErrorResponse(w, http.StatusBadRequest, "Binary cache with this host already exists")
+			return
+		}
+		if existingCache.Key == req.Key {
+			sendErrorResponse(w, http.StatusBadRequest, "Binary cache with this key already exists")
+			return
+		}
+	}
+
+	id := a.dbx.AddAction(dogeboxd.AddBinaryCache{Host: req.Host, Key: req.Key})
+	sendResponse(w, map[string]string{"id": id})
+}
+
+func (a api) removeBinaryCache(w http.ResponseWriter, r *http.Request) {
+	dbxState := a.sm.Get().Dogebox
+
+	cacheId := r.PathValue("id")
+	if cacheId == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Cache ID is required")
+		return
+	}
+
+	cacheFound := false
+	for _, cache := range dbxState.BinaryCaches {
+		if cache.ID == cacheId {
+			cacheFound = true
+			break
+		}
+	}
+
+	if !cacheFound {
+		sendErrorResponse(w, http.StatusBadRequest, "Binary cache with this ID does not exist")
+		return
+	}
+
+	id := a.dbx.AddAction(dogeboxd.RemoveBinaryCache{ID: cacheId})
+	sendResponse(w, map[string]string{"id": id})
+}

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -111,6 +111,10 @@ func RESTAPI(
 		"POST /system/welcome-complete":       a.setWelcomeComplete,
 		"POST /system/install-pup-collection": a.installPupCollection,
 		"GET /missing-deps/{PupID}":           a.getMissingDeps,
+
+		"GET /system/binary-caches":        a.getBinaryCaches,
+		"PUT /system/binary-cache":         a.addBinaryCache,
+		"DELETE /system/binary-cache/{id}": a.removeBinaryCache,
 	}
 
 	// We always want to load recovery routes.

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -15,9 +15,10 @@ import (
 )
 
 type InitialSystemBootstrapRequestBody struct {
-	ReflectorToken string `json:"reflectorToken"`
-	ReflectorHost  string `json:"reflectorHost"`
-	InitialSSHKey  string `json:"initialSSHKey"`
+	ReflectorToken           string `json:"reflectorToken"`
+	ReflectorHost            string `json:"reflectorHost"`
+	InitialSSHKey            string `json:"initialSSHKey"`
+	UseFoundationBinaryCache bool   `json:"useFoundationBinaryCache"`
 }
 
 type BootstrapFacts struct {
@@ -479,6 +480,19 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 		if err := t.dbx.SystemUpdater.EnableSSH(log); err != nil {
 			log.Errf("Error enabling SSH: %v", err)
 			sendErrorResponse(w, http.StatusInternalServerError, "Error enabling SSH")
+			return
+		}
+	}
+
+	if requestBody.UseFoundationBinaryCache {
+		// This is a bit of a hack until we can dispatch and then block,
+		// until a job has finished through the queue.
+		if err := t.dbx.SystemUpdater.AddBinaryCache(dogeboxd.AddBinaryCache{
+			Host: "https://nix.dogecoin.org",
+			Key:  "nix.dogecoin.org:PeUX5ftpdp5W3h827irwXxMZZr/4PGfHvSmV+2o6rC4=",
+		}, log); err != nil {
+			log.Errf("Error adding foundation binary cache: %v", err)
+			sendErrorResponse(w, http.StatusInternalServerError, "Error adding foundation binary cache")
 			return
 		}
 	}

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -15,10 +15,11 @@ import (
 )
 
 type InitialSystemBootstrapRequestBody struct {
-	ReflectorToken           string `json:"reflectorToken"`
-	ReflectorHost            string `json:"reflectorHost"`
-	InitialSSHKey            string `json:"initialSSHKey"`
-	UseFoundationBinaryCache bool   `json:"useFoundationBinaryCache"`
+	ReflectorToken              string `json:"reflectorToken"`
+	ReflectorHost               string `json:"reflectorHost"`
+	InitialSSHKey               string `json:"initialSSHKey"`
+	UseFoundationOSBinaryCache  bool   `json:"useFoundationOSBinaryCache"`
+	UseFoundationPupBinaryCache bool   `json:"useFoundationPupBinaryCache"`
 }
 
 type BootstrapFacts struct {
@@ -484,15 +485,28 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if requestBody.UseFoundationBinaryCache {
+	if requestBody.UseFoundationOSBinaryCache {
 		// This is a bit of a hack until we can dispatch and then block,
 		// until a job has finished through the queue.
 		if err := t.dbx.SystemUpdater.AddBinaryCache(dogeboxd.AddBinaryCache{
-			Host: "https://nix.dogecoin.org",
-			Key:  "nix.dogecoin.org:PeUX5ftpdp5W3h827irwXxMZZr/4PGfHvSmV+2o6rC4=",
+			Host: "https://dbx.nix.dogecoin.org",
+			Key:  "dbx.nix.dogecoin.org:ODXaHC+9DNqXQ8ZTijaCT4JpieqmOatZeZBbdN51Obc=",
 		}, log); err != nil {
-			log.Errf("Error adding foundation binary cache: %v", err)
-			sendErrorResponse(w, http.StatusInternalServerError, "Error adding foundation binary cache")
+			log.Errf("Error adding foundation OS binary cache: %v", err)
+			sendErrorResponse(w, http.StatusInternalServerError, "Error adding foundation OS binary cache")
+			return
+		}
+	}
+
+	if requestBody.UseFoundationPupBinaryCache {
+		// This is a bit of a hack until we can dispatch and then block,
+		// until a job has finished through the queue.
+		if err := t.dbx.SystemUpdater.AddBinaryCache(dogeboxd.AddBinaryCache{
+			Host: "https://pups.nix.dogecoin.org",
+			Key:  "pups.nix.dogecoin.org:hQx/w1TQlN423VyK+D/AnD10Ul8ovVxLcPrMRBt9T3Q=",
+		}, log); err != nil {
+			log.Errf("Error adding foundation pups binary cache: %v", err)
+			sendErrorResponse(w, http.StatusInternalServerError, "Error adding foundation pups binary cache")
 			return
 		}
 	}


### PR DESCRIPTION
This adds support for configuring Nix Binary Caches.

During setup, we'll allow users to opt-out (as most people will probably want?) of using the Foundation binary cache (https://nix.dogecoin.org) so that they don't have to compile pups such as Dogecoin Core, which typically take 20m+ on normal hardware. 

This doesn't mean that the end users have to trust published binaries though, as Nix still does its fully deterministic verification of the built binaries to ensure nothing has changed.