### PR TITLE
Allow change password via recovery mode with current password or seedphrase

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -59,8 +59,9 @@ func RESTAPI(
 
 	// Recovery routes are the _only_ routes loaded in recovery mode.
 	recoveryRoutes := map[string]http.HandlerFunc{
-		"POST /authenticate": a.authenticate,
-		"POST /logout":       a.logout,
+		"POST /authenticate":    a.authenticate,
+		"POST /logout":          a.logout,
+		"POST /change-password": a.changePassword,
 
 		"GET /system/bootstrap":          a.getBootstrap,
 		"GET /system/recovery-bootstrap": a.getRecoveryBootstrap,

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -304,12 +304,8 @@ func (t api) changePassword(w http.ResponseWriter, r *http.Request) {
 			sendErrorResponse(w, 400, "Authentication method required")
 		case "length":
 			sendErrorResponse(w, 403, "Invalid mnemonic length")
-		case "wordlist":
+		case "seedphrase":
 			sendErrorResponse(w, 403, "Invalid mnemonic word")
-		case "checksum":
-			sendErrorResponse(w, 403, "Invalid mnemonic checksum")
-		case "mnemonic":
-			sendErrorResponse(w, 403, "Invalid mnemonic phrase")
 		default:
 			sendErrorResponse(w, 500, "Failed to change password: "+err.Error())
 		}

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -259,3 +259,70 @@ func (t api) logout(w http.ResponseWriter, r *http.Request) {
 		"success": true,
 	})
 }
+
+type ChangePasswordRequestBody struct {
+	CurrentPassword string `json:"current_password"`
+	Seedphrase      string `json:"seedphrase"`
+	NewPassword     string `json:"new_password"`
+}
+
+func (t api) changePassword(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error reading request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var requestBody ChangePasswordRequestBody
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		http.Error(w, "Error parsing payload", http.StatusBadRequest)
+		return
+	}
+
+	// Validate that either current_password or seedphrase is provided
+	if requestBody.CurrentPassword == "" && requestBody.Seedphrase == "" {
+		sendErrorResponse(w, 400, "Either current_password or seedphrase must be provided")
+		return
+	}
+
+	// Change the password
+	if err := t.dkm.ChangePassword(requestBody.CurrentPassword, requestBody.Seedphrase, requestBody.NewPassword); err != nil {
+		// Map DKM error codes to appropriate HTTP responses
+
+		log.Println("DKM error:", err)
+		switch err.Error() {
+		case "password":
+			sendErrorResponse(w, 403, "Invalid credentials")
+		case "newpassword":
+			sendErrorResponse(w, 400, "New password cannot be empty")
+		case "bad-request":
+			sendErrorResponse(w, 400, "Invalid request format")
+		case "nokey":
+			sendErrorResponse(w, 400, "Master key not created")
+		case "auth":
+			sendErrorResponse(w, 400, "Authentication method required")
+		case "length":
+			sendErrorResponse(w, 403, "Invalid mnemonic length")
+		case "wordlist":
+			sendErrorResponse(w, 403, "Invalid mnemonic word")
+		case "checksum":
+			sendErrorResponse(w, 403, "Invalid mnemonic checksum")
+		case "mnemonic":
+			sendErrorResponse(w, 403, "Invalid mnemonic phrase")
+		default:
+			sendErrorResponse(w, 500, "Failed to change password: "+err.Error())
+		}
+		return
+	}
+
+	// Invalidate all existing sessions since they're using the old password
+	for _, session := range sessions {
+		t.dkm.InvalidateToken(session.DKM_TOKEN)
+	}
+	sessions = nil
+
+	sendResponse(w, map[string]any{
+		"success": true,
+	})
+}


### PR DESCRIPTION
Change summary:
- Added new ChangePassword function. Takes a new password, and either the current password or seedphrase to pass to DKM


Sibling PR for dpanel - https://github.com/Dogebox-WG/dpanel/pull/125
Sibling PR for dkm - https://github.com/Dogebox-WG/dkm/pull/2