### PR TITLE
General improvements to pup install/uninstall workflows

### DIFF
--- a/pkg/pups.go
+++ b/pkg/pups.go
@@ -39,6 +39,7 @@ const (
 const (
 	PUP_CHANGED_INSTALLATION int = iota
 	PUP_ADOPTED                  = iota
+	PUP_PURGED                   = iota
 )
 
 // PupManager Errors

--- a/pkg/system/updater.go
+++ b/pkg/system/updater.go
@@ -194,7 +194,7 @@ func (t SystemUpdater) installPup(pupSelection dogeboxd.InstallPup, j dogeboxd.J
 
 	// Compare the sha256 hash of the nix file to the hash specified in the manifest
 	if fmt.Sprintf("%x", nixFileSha256) != s.Manifest.Container.Build.NixFileSha256 {
-		log.Errf("Nix file hash mismatch")
+		log.Errf("Nix file hash mismatch, should be %s but is %s", fmt.Sprintf("%x", nixFileSha256), s.Manifest.Container.Build.NixFileSha256)
 		return t.markPupBroken(s, dogeboxd.BROKEN_REASON_NIX_HASH_MISMATCH, err)
 	}
 

--- a/pkg/web/admin_router.go
+++ b/pkg/web/admin_router.go
@@ -67,8 +67,7 @@ func (t AdminRouter) Run(started, stopped chan bool, stop chan context.Context) 
 					if !ok {
 						break mainloop
 					}
-					if p.Event == dogeboxd.PUP_ADOPTED {
-						// New pup adopted, update proxies
+					if p.Event == dogeboxd.PUP_ADOPTED || p.Event == dogeboxd.PUP_CHANGED_INSTALLATION || p.Event == dogeboxd.PUP_PURGED {
 						t.updateProxies()
 					}
 				}
@@ -103,6 +102,7 @@ func (t *adminProxy) Start() {
 	proxyURL, err := url.Parse(target)
 	if err != nil {
 		log.Fatalf("Failed to parse URL: %v", err)
+		return
 	}
 
 	httpServer := &http.Server{


### PR DESCRIPTION
Recover pups that become stuck 'installing' - mark them as broken.
Update proxies not just when dogeboxd.PUP_ADOPTED fired but also for dogeboxd.PUP_CHANGED_INSTALLATION and dogeboxd.PUP_PURGED.
Check port for new pup is available.
Log expected hash when nix file hash doesn't match.