### PR TITLE
Correctly check mountpaths when determining root device

### DIFF
--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -375,6 +375,7 @@ type SystemDisk struct {
 	BootMedia   bool                  `json:"bootMedia"`
 	Label       string                `json:"label"`
 	Path        string                `json:"path"`
+	MountPoints []string              `json:"mountPoints,omitempty"`
 	Children    []SystemDisk          `json:"children,omitempty"`
 }
 


### PR DESCRIPTION
This fixes the issue that @patowens keeps running into while in Orbstack. Orb mounts the root device at many different mountpoints, so we need to check all of those to see if that specific disk is the root disk that is being served.