### PR TITLE
Allow pups to be installed in a dev mode

### DIFF
--- a/cmd/dbx/cmd/can-pup-start.go
+++ b/cmd/dbx/cmd/can-pup-start.go
@@ -54,17 +54,22 @@ var canPupStartCmd = &cobra.Command{
 			return
 		}
 
-		// Ideally we wouldn't have to init all these things.
-		systemMonitor := system.NewSystemMonitor(dogeboxd.ServerConfig{})
+		config := dogeboxd.ServerConfig{
+			DataDir: dataDir,
+			TmpDir:  "/tmp",
+		}
 
-		pupManager, err := pup.NewPupManager(dataDir, "/tmp", systemMonitor)
+		// Ideally we wouldn't have to init all these things.
+		systemMonitor := system.NewSystemMonitor(config)
+
+		pupManager, err := pup.NewPupManager(config, systemMonitor)
 		if err != nil {
 			log.Println("Failed to load PupManager: ", err)
 			utils.ExitBad(systemd)
 			return
 		}
 
-		sourceManager := source.NewSourceManager(dogeboxd.ServerConfig{}, sm, pupManager)
+		sourceManager := source.NewSourceManager(config, sm, pupManager)
 		pupManager.SetSourceManager(sourceManager)
 
 		canStart, err := pupManager.CanPupStart(pupId)

--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -36,7 +36,7 @@ func Server(sm dogeboxd.StateManager, store *dogeboxd.StoreManager, config dogeb
 func (t server) Start() {
 	systemMonitor := system.NewSystemMonitor(t.config)
 
-	pups, err := pup.NewPupManager(t.config.DataDir, t.config.TmpDir, systemMonitor)
+	pups, err := pup.NewPupManager(t.config, systemMonitor)
 	if err != nil {
 		log.Fatalf("Failed to load Pup state: %+v", err)
 	}

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -246,10 +246,10 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 
 	// System actions
 	case InstallPup:
-		t.createPupFromManifest(j, a.PupName, a.PupVersion, a.SourceId)
+		t.createPupFromManifest(j, a.PupName, a.PupVersion, a.SourceId, a.Options)
 	case InstallPups:
 		for _, pup := range a {
-			t.createPupFromManifest(j, pup.PupName, pup.PupVersion, pup.SourceId)
+			t.createPupFromManifest(j, pup.PupName, pup.PupVersion, pup.SourceId, pup.Options)
 		}
 	case UninstallPup:
 		t.sendSystemJobWithPupDetails(j, a.PupID)
@@ -302,7 +302,7 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 *
 * Future: support multiple pup instances per manifest
  */
-func (t *Dogeboxd) createPupFromManifest(j Job, pupName, pupVersion, sourceId string) {
+func (t *Dogeboxd) createPupFromManifest(j Job, pupName, pupVersion, sourceId string, pupOptions AdoptPupOptions) {
 	// Fetch the correct manifest from the source manager
 	manifest, source, err := t.sources.GetSourceManifest(sourceId, pupName, pupVersion)
 	if err != nil {
@@ -312,7 +312,7 @@ func (t *Dogeboxd) createPupFromManifest(j Job, pupName, pupVersion, sourceId st
 	}
 
 	// create a new pup for the manifest
-	pupID, err := t.Pups.AdoptPup(manifest, source)
+	pupID, err := t.Pups.AdoptPup(manifest, source, pupOptions)
 	if err != nil {
 		j.Err = fmt.Sprintf("Couldn't create pup: %s", err)
 		t.sendFinishedJob("action", j)
@@ -326,7 +326,7 @@ func (t *Dogeboxd) createPupFromManifest(j Job, pupName, pupVersion, sourceId st
 // Handle batch installation of multiple pups
 func (t *Dogeboxd) installPups(j Job, pups InstallPups) {
 	for _, pup := range pups {
-		t.createPupFromManifest(j, pup.PupName, pup.PupVersion, pup.SourceId)
+		t.createPupFromManifest(j, pup.PupName, pup.PupVersion, pup.SourceId, pup.Options)
 	}
 }
 

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -49,9 +49,11 @@ type Action any
 
 // Install a pup on the system
 type InstallPup struct {
-	PupName      string
-	PupVersion   string
-	SourceId     string
+	PupName    string
+	PupVersion string
+	SourceId   string
+	Options    AdoptPupOptions
+
 	SessionToken string
 }
 

--- a/pkg/pup/manager.go
+++ b/pkg/pup/manager.go
@@ -27,8 +27,8 @@ const (
  */
 
 type PupManager struct {
+	config            dogeboxd.ServerConfig
 	pupDir            string // Where pup state is stored
-	tmpDir            string // Where temporary files are stored
 	lastIP            net.IP // last issued IP address
 	lastPort          int    // last issued Port
 	mu                *sync.Mutex
@@ -40,8 +40,8 @@ type PupManager struct {
 	sourceManager     dogeboxd.SourceManager
 }
 
-func NewPupManager(dataDir string, tmpDir string, monitor dogeboxd.SystemMonitor) (*PupManager, error) {
-	pupDir := filepath.Join(dataDir, "pups")
+func NewPupManager(config dogeboxd.ServerConfig, monitor dogeboxd.SystemMonitor) (*PupManager, error) {
+	pupDir := filepath.Join(config.DataDir, "pups")
 
 	if _, err := os.Stat(pupDir); os.IsNotExist(err) {
 		log.Printf("Pup directory %q not found, creating it", pupDir)
@@ -53,8 +53,8 @@ func NewPupManager(dataDir string, tmpDir string, monitor dogeboxd.SystemMonitor
 
 	mu := sync.Mutex{}
 	p := PupManager{
+		config:            config,
 		pupDir:            pupDir,
-		tmpDir:            tmpDir,
 		state:             map[string]*dogeboxd.PupState{},
 		stats:             map[string]*dogeboxd.PupStats{},
 		updateSubscribers: map[chan dogeboxd.Pupdate]bool{},

--- a/pkg/pup/storage.go
+++ b/pkg/pup/storage.go
@@ -53,7 +53,7 @@ func (t PupManager) loadPups() error {
 /* saves a pup to storage */
 func (t PupManager) savePup(p *dogeboxd.PupState) error {
 	path := filepath.Join(t.pupDir, fmt.Sprintf("pup_%s.gob", p.ID))
-	tempFile, err := os.CreateTemp(t.tmpDir, fmt.Sprintf("temp_%s", p.ID))
+	tempFile, err := os.CreateTemp(t.config.TmpDir, fmt.Sprintf("temp_%s", p.ID))
 	if err != nil {
 		return fmt.Errorf("cannot create temporary file: %w", err)
 	}

--- a/pkg/pups.go
+++ b/pkg/pups.go
@@ -81,6 +81,9 @@ type PupState struct {
 	IP           string                      `json:"ip"`           // Internal IP for this pup
 	Version      string                      `json:"version"`
 	WebUIs       []PupWebUI                  `json:"webUIs"`
+
+	IsDevModeEnabled bool     `json:"isDevModeEnabled"`
+	DevModeServices  []string `json:"devModeServices"`
 }
 
 // Represents a Web UI exposed port from the manifest
@@ -182,6 +185,11 @@ func (b *Buffer[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.GetValues())
 }
 
+type AdoptPupOptions struct {
+	/// Install pup with development features enabled
+	DevMode bool
+}
+
 /* The PupManager is responsible for all aspects of the pup lifecycle
  * see pkg/pup/manager.go
  */
@@ -205,7 +213,7 @@ type PupManager interface {
 	GetAssetsMap() map[string]PupAsset
 
 	// AdoptPup adds a new pup from a manifest. It returns the PupID and an error if any.
-	AdoptPup(m PupManifest, source ManifestSource) (string, error)
+	AdoptPup(m PupManifest, source ManifestSource, options AdoptPupOptions) (string, error)
 
 	// UpdatePup updates the state of a pup with provided update functions.
 	UpdatePup(id string, updates ...func(*PupState, *[]Pupdate)) (PupState, error)

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -251,6 +251,9 @@ type NixPupContainerTemplateValues struct {
 	SERVICES     []NixPupContainerServiceValues
 	PUP_ENV      []EnvEntry
 	GLOBAL_ENV   []EnvEntry
+
+	IS_DEV_MODE       bool
+	DEV_MODE_SERVICES []string
 }
 
 type NixSystemContainerConfigTemplatePupRequiresInternet struct {

--- a/pkg/web/collections.go
+++ b/pkg/web/collections.go
@@ -63,6 +63,7 @@ func processPupCollections(sm dogeboxd.StateManager, dbx dogeboxd.Dogeboxd, sess
 			PupName:      pup.Name,
 			PupVersion:   pup.Version,
 			SourceId:     pup.SourceId,
+			Options:      dogeboxd.AdoptPupOptions{},
 			SessionToken: sessionToken,
 		}
 	}

--- a/pkg/web/pups.go
+++ b/pkg/web/pups.go
@@ -125,6 +125,7 @@ func (t api) installPup(w http.ResponseWriter, r *http.Request) {
 			PupName:      req.PupName,
 			PupVersion:   req.PupVersion,
 			SourceId:     req.SourceId,
+			Options:      dogeboxd.AdoptPupOptions{},
 			SessionToken: req.SessionToken,
 		})
 
@@ -154,6 +155,7 @@ func (t api) installPup(w http.ResponseWriter, r *http.Request) {
 		PupName:      req.PupName,
 		PupVersion:   req.PupVersion,
 		SourceId:     req.SourceId,
+		Options:      dogeboxd.AdoptPupOptions{},
 		SessionToken: req.SessionToken,
 	})
 	sendResponse(w, map[string]string{"id": id})
@@ -277,6 +279,7 @@ func (t api) installPups(w http.ResponseWriter, r *http.Request) {
 				PupName:      pup.PupName,
 				PupVersion:   pup.PupVersion,
 				SourceId:     pup.SourceId,
+				Options:      dogeboxd.AdoptPupOptions{},
 				SessionToken: pup.SessionToken,
 			})
 
@@ -291,6 +294,7 @@ func (t api) installPups(w http.ResponseWriter, r *http.Request) {
 							PupName:      provider.PupName,
 							PupVersion:   provider.PupVersion,
 							SourceId:     pup.SourceId, // Use same source for dependencies
+							Options:      dogeboxd.AdoptPupOptions{},
 							SessionToken: pup.SessionToken,
 						})
 					}


### PR DESCRIPTION
This allows pups to be installed in a "dev" mode for `disk` (only) sources.

This:
- Mounts the root source inside the nix container (rather than the copied pup location)
- Sets `/pup` to be read-write instead of read-only.
- Allows specifying a specific "dev" build for each service in the pups nix file.

Still a couple things to do:

- [ ] Ignore hash mismatches in dev
- [ ] Report developer warnings to the UI (such as the above)
- [ ] Wire through `devmode=true` param from the frontend