### PR TITLE
optional yubikey

### DIFF
--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -74,8 +74,6 @@ in
         "tee0"     = { mountPoint = "/dev/tee0";     hostPath = "/dev/tee0";     isReadOnly = false; };
         "teepriv0" = { mountPoint = "/dev/teepriv0"; hostPath = "/dev/teepriv0"; isReadOnly = false; };
         "usb-bus"  = { mountPoint = "/dev/bus/usb";  hostPath = "/dev/bus/usb";  isReadOnly = false; };
-        "hidraw0"  = { mountPoint = "/dev/hidraw0";  hostPath = "/dev/hidraw0";  isReadOnly = false; };
-        "hidraw1"  = { mountPoint = "/dev/hidraw1";  hostPath = "/dev/hidraw1";  isReadOnly = false; };
       })
     ];
 


### PR DESCRIPTION
remove hidraw bind mounts. they caused nspawn failures when /dev/hidraw* isn’t present and aren’t needed for yubikey support.