### PR TITLE
Clean up installation state logic

### DIFF
--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -378,10 +378,17 @@ type SystemDisk struct {
 	Children    []SystemDisk          `json:"children,omitempty"`
 }
 
-type BootstrapInstallationMode string
+type BootstrapInstallationBootMedia string
 
 const (
-	BootstrapInstallationModeCanInstall    BootstrapInstallationMode = "canInstall"
-	BootstrapInstallationModeMustInstall   BootstrapInstallationMode = "mustInstall"
-	BootstrapInstallationModeCannotInstall BootstrapInstallationMode = "cannotInstall"
+	BootstrapInstallationMediaReadOnly  BootstrapInstallationBootMedia = "ro" // SD or ISO
+	BootstrapInstallationMediaReadWrite BootstrapInstallationBootMedia = "rw" // installed to eMMC or other permanent storage in a VM
+)
+
+type BootstrapInstallationState string
+
+const (
+	BootstrapInstallationStateUnconfigured BootstrapInstallationState = "unconfigured"
+	BootstrapInstallationStateNotInstalled BootstrapInstallationState = "notInstalled"
+	BootstrapInstallationStateConfigured   BootstrapInstallationState = "configured"
 )

--- a/pkg/system/installation.go
+++ b/pkg/system/installation.go
@@ -40,23 +40,40 @@ func IsInstalled(t dogeboxd.Dogeboxd, config dogeboxd.ServerConfig, dbxState dog
 	return checkNixOSDisksForFile(t, config, "/opt/dbx-installed")
 }
 
-func GetInstallationMode(t dogeboxd.Dogeboxd, dbxState dogeboxd.DogeboxState) (dogeboxd.BootstrapInstallationMode, error) {
-	// If we've been configured, no install for you.
-	if dbxState.InitialState.HasFullyConfigured {
-		return dogeboxd.BootstrapInstallationModeCannotInstall, nil
-	}
-
-	// Check if we're running on RO installation media. If so, must install.
+// Dogebox OS installation state based on boot drive type is either:
+// From Installation Media (Read-Only mode):
+// - No Installed OS - BootstrapInstallationStateNotInstalled
+// - Installed, Unconfigured OS - BootstrapInstallationStateUnconfigured
+// - Installed, Configured OS - BootstrapInstallationStateConfigured
+// From Installed Location (not Read-Only mode):
+// - Installed, Unconfigured - BootstrapInstallationStateUnconfigured
+// - Installed, Configured - BootstrapInstallationStateConfigured
+func GetInstallationState(t dogeboxd.Dogeboxd, config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState) (dogeboxd.BootstrapInstallationBootMedia, dogeboxd.BootstrapInstallationState, error) {
+	bootMedia := dogeboxd.BootstrapInstallationMediaReadWrite
 	isReadOnlyInstallationMedia, err := isReadOnlyInstallationMedia(t, "")
 	if err != nil {
-		return "", fmt.Errorf("error checking for RO installation media: %v", err)
+		return bootMedia, "", fmt.Errorf("error checking for RO installation media: %v", err)
 	}
 	if isReadOnlyInstallationMedia {
-		return dogeboxd.BootstrapInstallationModeMustInstall, nil
+		bootMedia = dogeboxd.BootstrapInstallationMediaReadOnly
 	}
 
-	// Otherwise, the user can optionally install.
-	return dogeboxd.BootstrapInstallationModeCanInstall, nil
+	// If we've been configured, no install for you.
+	if dbxState.InitialState.HasFullyConfigured {
+		return bootMedia, dogeboxd.BootstrapInstallationStateConfigured, nil
+	}
+
+	isInstalled, err := IsInstalled(t, config, dbxState)
+	if err != nil {
+		log.Printf("Could not determine if system is installed: %v", err)
+		isInstalled = false
+	}
+
+	if isInstalled {
+		return bootMedia, dogeboxd.BootstrapInstallationStateUnconfigured, nil
+	}
+
+	return bootMedia, dogeboxd.BootstrapInstallationStateNotInstalled, nil
 }
 
 func isReadOnlyInstallationMedia(t dogeboxd.Dogeboxd, mountPoint string) (bool, error) {
@@ -342,15 +359,6 @@ func InstallToDisk(t dogeboxd.Dogeboxd, config dogeboxd.ServerConfig, dbxState d
 
 	if !config.Recovery {
 		return fmt.Errorf("installation can only be done in recovery mode")
-	}
-
-	installMode, err := GetInstallationMode(t, dbxState)
-	if err != nil {
-		return err
-	}
-
-	if installMode != dogeboxd.BootstrapInstallationModeMustInstall && installMode != dogeboxd.BootstrapInstallationModeCanInstall {
-		return fmt.Errorf("installation is not possible with current system state: %s", installMode)
 	}
 
 	disks, err := GetSystemDisks()

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -63,8 +63,8 @@ func (t api) getRawBS() BootstrapResponse {
 }
 
 type RecoveryFacts struct {
-	InstallationMode dogeboxd.BootstrapInstallationMode `json:"installationMode"`
-	IsInstalled      bool                               `json:"isInstalled"`
+	InstallationBootMedia dogeboxd.BootstrapInstallationBootMedia `json:"installationBootMedia"`
+	InstallationState     dogeboxd.BootstrapInstallationState     `json:"installationState"`
 }
 
 type BootstrapRecoveryResponse struct {
@@ -74,21 +74,16 @@ type BootstrapRecoveryResponse struct {
 func (t api) getRecoveryBS() BootstrapRecoveryResponse {
 	dbxState := t.sm.Get().Dogebox
 
-	installationMode, err := system.GetInstallationMode(t.dbx, dbxState)
+	installationMedia, installationState, err := system.GetInstallationState(t.dbx, t.config, dbxState)
 	if err != nil {
 		log.Printf("Could not determine installation mode: %v", err)
-		installationMode = dogeboxd.BootstrapInstallationModeCannotInstall
-	}
-	isInstalled, err := system.IsInstalled(t.dbx, t.config, dbxState)
-	if err != nil {
-		log.Printf("Could not determine if system is installed: %v", err)
-		isInstalled = false
+		installationState = dogeboxd.BootstrapInstallationStateNotInstalled
 	}
 
 	return BootstrapRecoveryResponse{
 		RecoveryFacts: RecoveryFacts{
-			InstallationMode: installationMode,
-			IsInstalled:      isInstalled,
+			InstallationBootMedia: installationMedia,
+			InstallationState:     installationState,
 		},
 	}
 }


### PR DESCRIPTION
Fixes up the logic around showing the install to disk dialog options.

Change the naming from installation mode to installation state and add the installation boot media type.

The State will transition from "notInstalled" -> "unconfigured" -> "configured"
The ideal boot media for e.g. T6 is "ro" -> "rw" -> "rw"

Other combinations will end up showing different install to disk screens in dpanel. 