### PR TITLE
Raw copy u-boot from boot media partition 1 to target disk partition 1

### DIFF
--- a/cmd/_dbxroot/cmd/install-to-t6.go
+++ b/cmd/_dbxroot/cmd/install-to-t6.go
@@ -101,6 +101,7 @@ Example:
 		utils.RunParted(targetDisk, "set", "8", "boot", "on")
 		utils.RunParted(targetDisk, "set", "8", "legacy_boot", "on")
 
+		// Raw copy idbloader from boot media to target disk. idbloader sits between the end of the partition table and the start of the first partition.
 		utils.RunCommand("dd", "if="+bootMediaDisk.Name, "of="+targetDisk, "skip=64", "seek=64", "bs=100k", "count=4", "status=progress")
 
 		hasPartitionPrefix := strings.HasPrefix(targetDisk, "/dev/nvme") || strings.HasPrefix(targetDisk, "/dev/mmcblk")
@@ -109,9 +110,10 @@ Example:
 		if hasPartitionPrefix {
 			partitionPrefix = "p"
 		}
+		// Raw copy u-boot from boot media partition 1 to target disk partition 1
+		utils.RunCommand("dd", "if="+fmt.Sprintf("%s%s1", bootMediaDisk.Name, partitionPrefix), "of="+fmt.Sprintf("%s%s1", targetDisk, partitionPrefix), "status=progress")
 
 		rootPartition := fmt.Sprintf("%s%s8", targetDisk, partitionPrefix)
-
 		utils.RunCommand("mkfs.ext4", "-L", "nixos", rootPartition)
 
 		// Create /mnt if it doesn't exist, -p will prevent error if it already exists.


### PR DESCRIPTION
Re-implement patch from @stephenquoll in https://github.com/Dogebox-WG/dogeboxd/commit/0fa21ed48d3eea424565f4b8e07257bd34c43463 to fix compile errors.

Correctly copies the partition with u-boot to the target disk. This fixes an issue that could come up with an interrupted install where the data became corrupted causing the boot process to fail due to the bootloader not getting installed correctly.

The RK3588 boot process is very particular about having things in just the right places.