### PR TITLE
make sure to run mount-data-overlay before dogeboxd

### DIFF
--- a/pkg/system/nix/templates/storage-overlay.nix
+++ b/pkg/system/nix/templates/storage-overlay.nix
@@ -5,7 +5,12 @@
 
   systemd.services.mount-data-overlay = {
     description = "Mounts the selected storage device as an overlay at {{.DATA_DIR}}";
+    before = [ "dogeboxd.service" ];
     wantedBy = [ "local-fs.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = "yes";
+    };
     script = ''
       if ! ${pkgs.util-linux}/bin/mountpoint -q {{ .DATA_DIR }}; then
         ${pkgs.util-linux}/bin/mount {{ .STORAGE_DEVICE }} {{ .DATA_DIR }}


### PR DESCRIPTION
In some cases systemd was loading `mount-data-overlay` at the same time as `dogeboxd.service` causing the data-overlay for `/opt/dogebox` to not be properly mounted making `dogeboxd` see the original directory used during setup.

This only happened when using a separate storage device for data as selected during configuration and apparently only in a VM (tested on macOS with UTM)